### PR TITLE
Update key word arg name to value in dcc.Checklist

### DIFF
--- a/usage-advanced.py
+++ b/usage-advanced.py
@@ -67,7 +67,7 @@ app.layout = html.Div([
                     'controls',
                     'muted'
                 ]],
-                values=['controls']
+                value=['controls']
             ),
 
             html.P("Volume:", style={'margin-top': '10px'}),


### PR DESCRIPTION
- was "values" before

TypeError: The `dash_core_components.Checklist` component (version 1.14.1) with the ID "radio-bool-props" received an unexpected keyword argument: `values`
Allowed arguments: className, id, inputClassName, inputStyle, labelClassName, labelStyle, loading_state, options, persisted_props, persistence, persistence_type, style, value